### PR TITLE
fix unique path crash

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -50,8 +50,7 @@ class CopyArtifactsPlugin(BeetsPlugin):
                 break
         else:
             # No query matched; use original filename
-            file_path = os.path.join(mapping['albumpath'],
-                                     beets.util.displayable_path(filename))
+            file_path = os.path.join(mapping['albumpath'].encode('utf-8'), filename)
             return file_path
 
         if isinstance(path_format, Template):


### PR DESCRIPTION
simply fixes an old crash issue described here
https://github.com/sbarakat/beets-copyartifacts/issues/44
and solution as described here
https://github.com/sbarakat/beets-copyartifacts/pull/45

I just copied the solution but since this is the referenced fork in the beets documentation I guess it would be good if it got fixed
thanks @ssssam!