### PR TITLE
fix beets.mediafile deprecation warning

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -5,7 +5,7 @@ import filecmp
 import beets.util
 from beets import config
 from beets.ui import get_path_formats
-from beets.mediafile import TYPES
+from mediafile import TYPES
 from beets.plugins import BeetsPlugin
 from beets.library import DefaultTemplateFunctions
 from beets.util.functemplate import Template


### PR DESCRIPTION
beets.mediafile is deprecated and shows warning on every import 
fixes https://github.com/adammillerio/beets-copyartifacts/issues/3