### PR TITLE
Fix another path crash related to path encoding

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -65,7 +65,7 @@ class CopyArtifactsPlugin(BeetsPlugin):
         # Sanitize filename
         filename = beets.util.sanitize_path(os.path.basename(file_path))
         dirname = os.path.dirname(file_path)
-        file_path = os.path.join(dirname, filename)
+        file_path = os.path.join(dirname, filename).encode('utf-8')
 
         return file_path
 


### PR DESCRIPTION
This fixes another issue in the destination path function similar to #4 where a path is returned as a string rather than a bytestring, which causes a crash upstream:

```
Traceback (most recent call last):
  File "/home/user/.pyenv/versions/beets/bin/beet", line 11, in <module>
    load_entry_point('beets==1.6.0', 'console_scripts', 'beet')()
  File "/home/user/.pyenv/versions/3.8.1/envs/beets/lib/python3.8/site-packages/beets/ui/__init__.py", line 1285, in main
    _raw_main(args)
  File "/home/user/.pyenv/versions/3.8.1/envs/beets/lib/python3.8/site-packages/beets/ui/__init__.py", line 1274, in _raw_main
    plugins.send('cli_exit', lib=lib)
  File "/home/user/.pyenv/versions/3.8.1/envs/beets/lib/python3.8/site-packages/beets/plugins.py", line 488, in send
    result = handler(**arguments)
  File "/home/user/.pyenv/versions/3.8.1/envs/beets/lib/python3.8/site-packages/beets/plugins.py", line 145, in wrapper
    return func(*args, **kwargs)
  File "/home/user/beets-copyartifacts/beetsplug/copyartifacts.py", line 130, in process_events
    self.process_artifacts(item['files'], item['mapping'], False)
  File "/home/user/beets-copyartifacts/beetsplug/copyartifacts.py", line 144, in process_artifacts
    dest_file = self._destination(filename, mapping)
  File "/home/user/beets-copyartifacts/beetsplug/copyartifacts.py", line 70, in _destination
    file_path = os.path.join(dirname.encode('utf-8'), filename)
  File "/home/user/.pyenv/versions/3.8.1/lib/python3.8/posixpath.py", line 90, in join
    genericpath._check_arg_types('join', a, *p)
  File "/home/user/.pyenv/versions/3.8.1/lib/python3.8/genericpath.py", line 155, in _check_arg_types
    raise TypeError("Can't mix strings and bytes in path components") from None
TypeError: Can't mix strings and bytes in path components
```