### PR TITLE
Fix import crash with beets 2.13+ sorted_walk path types

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -13,6 +13,19 @@ from beets.util.functemplate import Template
 __version__ = '0.1.2'
 __author__ = 'Sami Barakat <sami@sbarakat.co.uk>'
 
+
+def _ignore_patterns_for_path(path, ignore_patterns):
+    """Return ignore glob patterns matching the type of ``path``.
+
+    Beets 2.13+ ``sorted_walk`` requires path components and ignore
+    patterns to share the same type (``str`` or ``bytes``). Item paths
+    are bytes, but config ignore patterns are strings.
+    """
+    if isinstance(path, str):
+        return ignore_patterns
+    return list(map(os.fsencode, ignore_patterns))
+
+
 class CopyArtifactsPlugin(BeetsPlugin):
     def __init__(self):
         super(CopyArtifactsPlugin, self).__init__()
@@ -102,9 +115,12 @@ class CopyArtifactsPlugin(BeetsPlugin):
         if source_path in self._dirs_seen:
             return
 
+        ignore = _ignore_patterns_for_path(
+            source_path, config['ignore'].as_str_seq()
+        )
         non_handled_files = []
         for root, dirs, files in beets.util.sorted_walk(
-                    source_path, ignore=config['ignore'].as_str_seq()):
+                    source_path, ignore=ignore):
             for filename in files:
                 source_file = os.path.join(root, filename)
 

--- a/tests/test_collect_artifacts.py
+++ b/tests/test_collect_artifacts.py
@@ -1,0 +1,50 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import beets.util
+from beets import config
+from beetsplug import copyartifacts
+
+
+class CollectArtifactsPathTypesTest(unittest.TestCase):
+    """Regression tests for beets 2.13+ path type handling."""
+
+    def setUp(self):
+        config.read(user=False, defaults=True)
+        config['ignore'] = ['.DS_Store', 'Thumbs.db']
+        self.temp_dir = beets.util.bytestring_path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(beets.util.syspath(self.temp_dir))
+        config.clear()
+        config._materialized = False
+
+    def test_bytes_paths_with_string_ignore_patterns(self):
+        """Item paths are bytes; config ignore patterns are strings."""
+        album_path = os.path.join(self.temp_dir, b'the_album')
+        os.makedirs(beets.util.syspath(album_path))
+        open(beets.util.syspath(os.path.join(album_path, b'artifact.file')), 'a').close()
+        open(beets.util.syspath(os.path.join(album_path, b'.DS_Store')), 'a').close()
+
+        plugin = copyartifacts.CopyArtifactsPlugin()
+        item = type('Item', (), {
+            'artist': 'Tag Artist',
+            'albumartist': 'Tag Artist',
+            'album': 'Tag Album',
+        })()
+        source = os.path.join(album_path, b'track.flac')
+        dest = os.path.join(
+            self.temp_dir, b'libdir', b'Tag Artist', b'Tag Album', b'track.flac'
+        )
+
+        plugin.collect_artifacts(item, source, dest)
+
+        files = plugin._process_queue[0]['files']
+        self.assertIn(os.path.join(album_path, b'artifact.file'), files)
+        self.assertNotIn(os.path.join(album_path, b'.DS_Store'), files)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fix `TypeError: cannot use a string pattern on a bytes-like object` when importing with beets 2.13+
- Encode config `ignore` glob patterns to bytes when walking byte paths from `item_copied` / `item_moved` events
- Add a regression test covering the bytes-path + string-ignore case

## Context

Beets 2.13 ([PR #6806](https://github.com/beetbox/beets/pull/6806)) made `sorted_walk()` generic over `str`/`bytes` and no longer coerces ignore patterns internally. Beets core updated its own importer (`albums_in_dir`) to encode ignore patterns when paths are bytes, but copyartifacts still passed `config['ignore'].as_str_seq()` (strings) while item paths are bytes.

## Test plan

- [x] `python -m unittest tests.test_collect_artifacts -v` passes against beets 2.13.1
- [ ] Full legacy test suite still needs updates for beets 2.13 API changes (separate from this fix)
